### PR TITLE
feat(metabase): add configurable startupProbe to Deployment

### DIFF
--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -44,6 +44,17 @@ spec:
               key: {{ .key }}
         {{- end }}
         {{- end }}
+        {{- if .Values.metabase.healthCheck.startup.enabled }}
+        startupProbe:
+          httpGet:
+            path: /api/health
+            port: {{ .Values.metabase.ports.http }}
+          initialDelaySeconds: {{ .Values.metabase.healthCheck.startup.initialDelaySeconds }}
+          periodSeconds: {{ .Values.metabase.healthCheck.startup.periodSeconds }}
+          timeoutSeconds: {{ .Values.metabase.healthCheck.startup.timeoutSeconds }}
+          successThreshold: {{ .Values.metabase.healthCheck.startup.successThreshold }}
+          failureThreshold: {{ .Values.metabase.healthCheck.startup.failureThreshold }}
+        {{- end }}
         readinessProbe:
           httpGet:
             path: /api/health

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -22,6 +22,25 @@ metabase:
   
   # -- Health check configuration
   healthCheck:
+    # -- Startup probe configuration. While the startup probe runs,
+    # liveness and readiness probes are suspended. Use it to give slow-
+    # starting JVM apps (Metabase Enterprise loads many drivers/plugins)
+    # enough time to come up before the liveness probe kicks in.
+    startup:
+      # -- Enable the startup probe
+      enabled: true
+      # -- Initial delay before startup probe starts (seconds)
+      initialDelaySeconds: 30
+      # -- Period between startup probe checks (seconds)
+      periodSeconds: 5
+      # -- Timeout for startup probe (seconds)
+      timeoutSeconds: 5
+      # -- Number of successful checks needed to consider the container started
+      successThreshold: 1
+      # -- Number of failed checks before giving up. Total window =
+      # initialDelaySeconds + (failureThreshold × periodSeconds).
+      # Default: 30 + 60×5 = 330s.
+      failureThreshold: 60
     # -- Readiness probe configuration
     readiness:
       # -- Initial delay before readiness probe starts (seconds)


### PR DESCRIPTION
## Summary

- Add a `startupProbe` to the Metabase Deployment template, configurable under `metabase.healthCheck.startup`.
- Default window: **330s** (30s initial + 60×5s) — enough for Metabase Enterprise's slow first boot (driver loading, plugin extraction, schema migration).
- Opt-out via `metabase.healthCheck.startup.enabled` (default `true`). Liveness and readiness defaults are unchanged.

## Why

On 2026-04-28, swan-* and metabase-corporate pods on prod cycled on first boot with `exitCode 143` (SIGTERM). Investigation showed Metabase took 3–5 min to serve `/api/health 200`, while the existing liveness probe (`90s + 10×15s = 240s`) would kill the container first. The second container start succeeded thanks to OS/disk cache being warm, but the first restart was systematic on cold deploys.

`startupProbe` is the canonical Kubernetes pattern for slow-starting JVM apps: it suspends liveness/readiness while it runs, then hands over once the app is up.

## Changes

- `charts/metabase/templates/deployment.yaml` — add gated `startupProbe` block before existing probes
- `charts/metabase/values.yaml` — add `metabase.healthCheck.startup` defaults

## Test plan

- [x] `helm lint charts/metabase` — clean
- [x] `helm template` — `startupProbe` present by default, absent when `metabase.healthCheck.startup.enabled=false`
- [x] Release-please bumps chart from `0.5.0` to `0.6.0` after merge (commit type `feat:`)
- [x] Consumers (`swan`, `metabase-service`) bump `targetRevision` to `0.6.0` and validate on staging

## Refs

- PLA-3267
- Related: PLA-3266 (Karpenter kubelet reservations, same incident)