### PR TITLE
ci: pin Traefik chart to 38.0.2 in kind setup task

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -26,7 +26,10 @@ run = [
   "helm repo update",
   "helm install vault-secrets-operator hashicorp/vault-secrets-operator --kube-context kind-kind --namespace vault --create-namespace",
   "helm install vault hashicorp/vault --kube-context kind-kind --namespace vault --set 'server.dev.enabled=true' --set 'server.dev.devRootToken=root'",
-  "helm install traefik traefik/traefik --kube-context kind-kind --namespace traefik --create-namespace --set ports.websecure.tls.enabled=true",
+  # Traefik chart 39.0.0 introduced a stricter schema that rejects
+  # ports.websecure.tls.enabled. Pinned to 38.0.2 (last version supporting
+  # the old schema) until we migrate the test setup. See PLA-3268.
+  "helm install traefik traefik/traefik --version 38.0.2 --kube-context kind-kind --namespace traefik --create-namespace --set ports.websecure.tls.enabled=true",
   "sleep 60",
   "kubectl wait --context kind-kind --for=condition=ready pod -l app.kubernetes.io/name=vault,component=server -n vault --timeout=300s",
   "kubectl exec --context kind-kind -n vault vault-0 -- vault auth enable kubernetes",


### PR DESCRIPTION
## Summary

- Pin Traefik chart to `38.0.2` in the `kind:setup` mise task to unblock CI on every PR.
- Traefik chart `39.0.0` introduced a stricter JSON schema that rejects `ports.websecure.tls.enabled`. Since the task didn't pin a version, Helm picked the latest and CI started failing on all PRs.

## Why

Sample failure (run on PR #32):

\`\`\`
Error: INSTALLATION FAILED: values don't meet the specifications of the schema(s):
traefik:
- at '/ports/websecure': additional properties 'tls' not allowed
\`\`\`

Verified locally:

| Traefik chart version | `--set ports.websecure.tls.enabled=true` |
| --- | --- |
| 36.3.0 | ok |
| 37.0.0 | ok |
| 38.0.2 | ok |
| 39.0.0+ | rejected |

This is a stop-gap. Long-term action (separate ticket): migrate the kind test setup to the new Traefik schema (likely `ports.websecure.tls: {}` block or move TLS config to IngressRoute), then bump the pin or remove it.

## Changes

- `.config/mise/config.toml` — pin `--version 38.0.2` on the Traefik install in `kind:setup`, with a comment pointing to PLA-3268.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge: PLA-3267 (#32) re-runs CI green

## Refs

- PLA-3268
- Unblocks: PLA-3267 (#32)