### PR TITLE
fix(metabase): wire javaToolOptions as JAVA_TOOL_OPTIONS env var

### DIFF
--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -39,7 +39,7 @@ A Helm chart to deploy a Metabase instance for Kubernetes in a context with Hash
 | metabase.ingress.entryPoints | list | `["internal"]` | Entry points for Traefik |
 | metabase.ingress.tls | object | `{"enabled":false,"secretName":""}` | TLS configuration |
 | metabase.ingress.url | string | `"metabase.example.com"` | IngressRoute URL/hostname |
-| metabase.javaOpts | string | `"-Xmx1g -Dc3p0.maxIdleTime=900 -Dc3p0.maxIdleTimeExcessConnections=1500"` | Java options for Metabase JVM |
+| metabase.javaToolOptions | string | `""` | Extra JVM options injected as JAVA_TOOL_OPTIONS. The JVM reads JAVA_TOOL_OPTIONS automatically in addition to JAVA_OPTS, so this extends rather than overrides image-level JVM configuration (e.g. log4j2 file location baked into a custom image). Typical use: heap sizing (-Xmx) and connection pool tuning. Empty by default. |
 | metabase.nodeSelector | object | `{}` | Node selector for pod placement |
 | metabase.ports | object | `{"http":3000}` | Port configuration |
 | metabase.ports.http | int | `3000` | HTTP port for Metabase container |

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -34,6 +34,10 @@ spec:
         - configMapRef:
             name: {{ .Values.global.service_name }}-config
         env:
+        {{- if .Values.metabase.javaToolOptions }}
+        - name: JAVA_TOOL_OPTIONS
+          value: {{ .Values.metabase.javaToolOptions | quote }}
+        {{- end }}
         {{- range .Values.metabase.secretsVars }}
         {{- $secretName := .name }}
         {{- range .envVars }}

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -81,8 +81,12 @@ metabase:
       memory: 2048Mi
   # -- Number of replicas
   replicas: 1
-  # -- Java options for Metabase JVM
-  javaOpts: "-Xmx1g -Dc3p0.maxIdleTime=900 -Dc3p0.maxIdleTimeExcessConnections=1500"
+  # -- Extra JVM options injected as JAVA_TOOL_OPTIONS. The JVM reads
+  # JAVA_TOOL_OPTIONS automatically in addition to JAVA_OPTS, so this
+  # extends rather than overrides image-level JVM configuration (e.g.
+  # log4j2 file location baked into a custom image). Typical use: heap
+  # sizing (-Xmx) and connection pool tuning. Empty by default.
+  javaToolOptions: ""
   # -- Pod tolerations
   tolerations: []
   # -- Node selector for pod placement


### PR DESCRIPTION
## Context

Commit 4ca6887 (Sep 2025) refactored JVM tuning out of `configMapVars` and introduced a new top-level `metabase.javaOpts` value, but the corresponding `templates/deployment.yaml` change to actually template that value into the container `env:` block was never made.

Result: for ~7 months in production, Metabase pods have been running with **no explicit `-Xmx`** and **no c3p0 idle timeout overrides**, falling back to JVM container-aware defaults instead of the values declared in the chart.

The log4j2 configuration kept working because it is baked into the custom `metabase_enterprise` image as `ENV JAVA_OPTS=-Dlog4j2.configurationFile=file:/smartway/log4j2.xml`.

## Change

- Wire JVM tuning via a renamed `metabase.javaToolOptions` value, injected as the `JAVA_TOOL_OPTIONS` env var.
- `JAVA_TOOL_OPTIONS` is read by the JVM **in addition to** `JAVA_OPTS`, so it extends image-level configuration rather than overriding it. Downstream consumers cannot accidentally drop image-level config (such as log4j2) by setting their own JVM options.
- Default value is empty (`""`) — opt-in by consumers.
- Drop the legacy `metabase.javaOpts` value (dead code since 4ca6887).

## Files

| File | Change |
|---|---|
| `charts/metabase/templates/deployment.yaml` | Add conditional `env:` entry injecting `JAVA_TOOL_OPTIONS` when `javaToolOptions` is non-empty |
| `charts/metabase/values.yaml` | Rename `javaOpts` → `javaToolOptions`, default to `""`, update inline doc |
| `charts/metabase/README.md` | Sync the single corresponding line |

## Validation

- `helm lint charts/metabase` → 0 errors
- `helm template charts/metabase` → no `JAVA_TOOL_OPTIONS` env when default
- `helm template charts/metabase --set metabase.javaToolOptions='-Xmx1g -Dfoo=bar'` → env injected with the quoted value

## Follow-up

A subsequent PR will land in the `swan` repo to set `javaToolOptions: "-Xmx1g -Dc3p0.maxIdleTime=900 -Dc3p0.maxIdleTimeExcessConnections=1500"` in the shared values, alongside a `requests.memory` bump.