### PR TITLE
fix(metabase): remove default CPU limit

### DIFF
--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -44,9 +44,8 @@ A Helm chart to deploy a Metabase instance for Kubernetes in a context with Hash
 | metabase.ports | object | `{"http":3000}` | Port configuration |
 | metabase.ports.http | int | `3000` | HTTP port for Metabase container |
 | metabase.replicas | int | `1` | Number of replicas |
-| metabase.resources | object | `{"limits":{"cpu":"1000m","memory":"2048Mi"},"requests":{"cpu":"500m","memory":"1024Mi"}}` | Resource requests and limits |
-| metabase.resources.limits | object | `{"cpu":"1000m","memory":"2048Mi"}` | Resource limits |
-| metabase.resources.limits.cpu | string | `"1000m"` | CPU limit |
+| metabase.resources | object | `{"limits":{"memory":"2048Mi"},"requests":{"cpu":"500m","memory":"1024Mi"}}` | Resource requests and limits |
+| metabase.resources.limits | object | `{"memory":"2048Mi"}` | Resource limits. CPU is intentionally unset: CFS throttling on the JVM (startup, GC pauses, request bursts) tends to cause more harm than capping is worth. CPU requests still ensure scheduling fairness. |
 | metabase.resources.limits.memory | string | `"2048Mi"` | Memory limit |
 | metabase.resources.requests | object | `{"cpu":"500m","memory":"1024Mi"}` | Resource requests |
 | metabase.resources.requests.cpu | string | `"500m"` | CPU request |

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -73,10 +73,11 @@ metabase:
       cpu: 500m
       # -- Memory request
       memory: 1024Mi
-    # -- Resource limits
+    # -- Resource limits. CPU is intentionally unset: CFS throttling on
+    # the JVM (startup, GC pauses, request bursts) tends to cause more
+    # harm than capping is worth. CPU requests still ensure scheduling
+    # fairness.
     limits:
-      # -- CPU limit
-      cpu: 1000m
       # -- Memory limit
       memory: 2048Mi
   # -- Number of replicas


### PR DESCRIPTION
## Context

The chart sets `metabase.resources.limits.cpu: 1000m` by default. CPU limits trigger CFS throttling at the kernel level, which interacts poorly with the JVM:

- **Cold start**: Metabase Enterprise loads many drivers and plugins; throttling at boot inflates startup time and increases the chance of startupProbe failures.
- **GC pauses**: any GC cycle that briefly needs more than 1 core gets stretched by throttling, increasing pause duration and tail latency.
- **Request bursts**: dashboards with concurrent queries naturally spike CPU; throttling caps response time visibly even when host CPU is idle.

CPU requests already guarantee scheduling fairness and minimum allocation. The limit was strictly counterproductive.

## Change

- Drop `metabase.resources.limits.cpu` from chart defaults.
- Memory limit preserved (hard cap is desirable to fail fast on JVM leaks).
- Inline doc explains the rationale so future contributors do not "fix" it back.

## Files

| File | Change |
|---|---|
| `charts/metabase/values.yaml` | Remove `limits.cpu`, add comment explaining the choice |
| `charts/metabase/README.md` | Sync the corresponding rows |

## Validation

- `helm lint charts/metabase` → 0 errors
- `helm template charts/metabase` → rendered `resources` block contains `limits.memory` and `requests.{cpu,memory}` only

## References

- https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#how-pods-with-resource-limits-are-run
- Tim Hockin (Kubernetes co-creator) on CPU limits being usually harmful: https://twitter.com/thockin/status/1134193838841401345