### PR TITLE
fix(ci): drop redundant Traefik CRD apply

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -20,7 +20,6 @@ run = [
 [tasks."kind:setup"]
 description = "Setup Vault and Traefik on kind cluster"
 run = [
-  "kubectl apply --context kind-kind -f https://raw.githubusercontent.com/traefik/traefik/v3.5/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml",
   "helm repo add hashicorp https://helm.releases.hashicorp.com",
   "helm repo add traefik https://traefik.github.io/charts",
   "helm repo update",


### PR DESCRIPTION
## Context

The release-please PR (#37) is failing CI on the `lint-test` job:

```
failed to install CRD crds/traefik.io_ingressroutes.yaml: conflict
occurred while applying object /ingressroutes.traefik.io
apiextensions.k8s.io/v1, Kind=CustomResourceDefinition: Apply failed
with 1 conflict: conflict with "kubectl-client-side-apply" using
apiextensions.k8s.io/v1: .spec.versions
```

## Root cause

The `kind:setup` mise task does two things on the same CRDs:

1. `kubectl apply` of Traefik CRDs from the upstream raw repo
2. `helm install traefik/traefik 38.0.2` — which ships and installs the same CRDs via the standard Helm `crds/` directory

Helm 3 silently tolerated the conflict (Client-Side Apply, last writer wins). The recent bump to Helm 4 (PR #18, merged today) uses Server-Side Apply with strict field-manager conflict detection, exposing the latent issue.

Each individual Renovate PR ran fine because they were tested in isolation. The conflict only surfaces now that Helm 4, kind 0.31, etc. are all on `main` together.

## Change

Remove the redundant `kubectl apply` line. The Traefik chart 38.0.2 already installs its CRDs via the `crds/` convention, so dropping the upstream raw apply leaves a single clean owner for those CRDs.

## Validation

- `helm install traefik/traefik 38.0.2` ships `crds/traefik.io_*.yaml` natively (verified by inspecting the chart contents).
- The setup script flow continues to work: vault + vault-secrets-operator + traefik are installed in sequence; CRDs needed by downstream IngressRoute resources from the metabase chart are present.

## Alternatives considered

- `--skip-crds` on `helm install traefik`: keeps the dual-mechanism dead-weight.
- Revert PR #18 (Helm 4 → 3): loses the v4.1.4 security fixes (chart name dot-segment, plugin signing, plugin path traversal).