### PR TITLE
fix(metabase): drop legacy JAVA_OPTS ConfigMap injection

### DIFF
--- a/charts/metabase/templates/configmap.yaml
+++ b/charts/metabase/templates/configmap.yaml
@@ -8,5 +8,4 @@ data:
   {{- range .Values.metabase.configMapVars }}
   {{ .name }}: {{ .value | quote }}
   {{- end }}
-  JAVA_OPTS: {{ .Values.metabase.javaOpts | quote }}
   MB_SITE_URL: https://{{ .Values.metabase.ingress.url }}/


### PR DESCRIPTION
## Critical — must merge before any consumer bumps to chart 0.6.1

## Context

Commit 37bbe6e (#35, merged earlier today) renamed `metabase.javaOpts` → `metabase.javaToolOptions` in `values.yaml` on the **incorrect** assumption that `javaOpts` was dead code.

The original assumption was based on grepping `templates/deployment.yaml` and finding no reference. However, `javaOpts` was actually wired through a second path I missed:

```yaml
# templates/configmap.yaml (current state on main)
data:
  ...
  JAVA_OPTS: {{ .Values.metabase.javaOpts | quote }}
```

That ConfigMap is consumed by the Deployment via `envFrom: configMapRef`, so `JAVA_OPTS` was being exported into every Metabase Pod. This is how `-Dlog4j2.configurationFile=…`, `-Xmx1g`, and the c3p0 idle timeouts were *actually* reaching the JVM in production all along — not via the Dockerfile `ENV` (which gets overridden by the PodSpec env), but via this ConfigMap path.

## Impact of the regression

After PR #35 merged, `metabase.javaOpts` no longer exists in `values.yaml`. The ConfigMap now renders an empty `JAVA_OPTS:` field. Once chart 0.6.1 is consumed by `swan`:

| Before (chart 0.6.0) | After (chart 0.6.1, current main) |
|---|---|
| `JAVA_OPTS=-Dlog4j2.configurationFile=…\ -Xmx1g -Dc3p0…` | `JAVA_OPTS=` (empty, overrides Dockerfile ENV) |
| log4j2 JSON layout active | log4j2 JSON layout **lost** → Datadog reads raw text |
| `-Xmx1g` heap cap explicit | JVM heap auto-tunes on cgroup |
| c3p0 idle timeouts overridden | c3p0 defaults |

Triple regression on all 14 swan instances + metabase-corporate the moment the chart version is bumped downstream.

## Change

Remove the `JAVA_OPTS` line from `configmap.yaml`. JVM tuning now flows **exclusively** through `metabase.javaToolOptions` (introduced in PR #35), which is injected as `JAVA_TOOL_OPTIONS` and **extends** the image-level `JAVA_OPTS` rather than overriding it. The `ENV JAVA_OPTS=-Dlog4j2…` baked into the `metabase_enterprise` image is therefore preserved at runtime.

Consumers (e.g. swan shared values) need to set `metabase.javaToolOptions` to opt into `-Xmx1g` and c3p0 tuning.

## Validation

- `helm lint charts/metabase` → 0 errors.
- `helm template charts/metabase` → ConfigMap no longer carries `JAVA_OPTS:`.
- Rendered Deployment env block now contains `JAVA_TOOL_OPTIONS` only when `javaToolOptions` is set, and the image-level `ENV JAVA_OPTS` flows through unmodified.

## Next steps after merge

1. Release-please opens 0.6.2 (or rolls into the existing release PR if still open).
2. The follow-up swan PR (already planned) sets `metabase.javaToolOptions: "-Xmx1g -Dc3p0.maxIdleTime=900 -Dc3p0.maxIdleTimeExcessConnections=1500"` and bumps the chart version in the 14 `instances/main/*.tfvars`.
3. `-Dlog4j2.configurationFile=…` is **not** included in `javaToolOptions` because it is already provided by the image's `ENV JAVA_OPTS`, which the additive `JAVA_TOOL_OPTIONS` no longer overrides.